### PR TITLE
Unused mongoose import

### DIFF
--- a/backend/seeder.js
+++ b/backend/seeder.js
@@ -1,4 +1,3 @@
-import mongoose from 'mongoose'
 import dotenv from 'dotenv'
 import colors from 'colors'
 import users from './data/users.js'


### PR DESCRIPTION
# Why is this a code smell?

This issue is a true code smell since unused imports can confuse other developers about whether the import is being used or not. This makes it difficult for other developers to read since they'll have to guess why a dev imported the module and track down where this import will be used even though it is not used. Removing this import makes the code more readable for other developers.