### PR TITLE
Remove OrderScreen ternary Operation

### DIFF
--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -85,11 +85,16 @@ const OrderScreen = ({ match, history }) => {
     dispatch(deliverOrder(order))
   }
 
-  return loading ? (
-    <Loader />
-  ) : error ? (
-    <Message variant='danger'>{error}</Message>
-  ) : (
+  const renderOrderContent = () => {
+    if (loading) {
+      return <Loader />;
+    }
+  
+    if (error) {
+      return <Message variant='danger'>{error}</Message>;
+    }
+
+    return (
     <>
       <h1>Order {order._id}</h1>
       <Row>
@@ -228,7 +233,11 @@ const OrderScreen = ({ match, history }) => {
         </Col>
       </Row>
     </>
-  )
-}
+    );
+  };
 
+  
+
+return renderOrderContent();
+};
 export default OrderScreen


### PR DESCRIPTION
# Why is this a code smell?

Ternary operations are a code smell because as the code base gets more complex, it makes the code more difficult to understand. This ternary operation can be put into a function that could be more easily maintained as the code base grows in complexity. 

In this case, I created a function called renderOrderContent with the ternary operation code, and now the code is more easily readable and maintainable because I used if-else statements and put the code into a separate function instead of using the ternary operation.