### PR TITLE
Removed array keys

### DIFF
--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -138,8 +138,8 @@ const OrderScreen = ({ match, history }) => {
                 <Message>Order is empty</Message>
               ) : (
                 <ListGroup variant='flush'>
-                  {order.orderItems.map((item, index) => (
-                    <ListGroup.Item key={index}>
+                  {order.orderItems.map((item) => (
+                    <ListGroup.Item key={item.product}>
                       <Row>
                         <Col md={1}>
                           <Image


### PR DESCRIPTION
# Why is this a code smell?

Having array indexes as keys is a code smell because of unexpected behaviors when trying the use the items in a list. If the order of list items changes, the code can't properly track the component's state allowing unexpected behaviors to happen. This can also lead to incorrect rendering where the keys don't reflect the actual items, so modifying the code to have a unique identifier as the key prevent these issues from happening.