### PR TITLE
extract ternary operator Fixes #24

### DIFF
--- a/frontend/src/screens/UserListScreen.js
+++ b/frontend/src/screens/UserListScreen.js
@@ -31,16 +31,15 @@ const UserListScreen = ({ history }) => {
       dispatch(deleteUser(id))
     }
   }
-
-  return (
-    <>
-      <h1>Users</h1>
-      {loading ? (
-        <Loader />
-      ) : error ? (
-        <Message variant='danger'>{error}</Message>
-      ) : (
-        <Table striped bordered hover responsive className='table-sm'>
+  if (loading){
+    return (<Loader />);
+  }
+  else {
+    if (error){
+      return (<Message variant='danger'>{error}</Message>);
+    }
+    else {
+        return (<Table striped bordered hover responsive className='table-sm'>
           <thead>
             <tr>
               <th>ID</th>
@@ -82,10 +81,9 @@ const UserListScreen = ({ history }) => {
               </tr>
             ))}
           </tbody>
-        </Table>
-      )}
-    </>
-  )
+        </Table>);
+    }
+  }
 }
 
 export default UserListScreen


### PR DESCRIPTION
# Why is this a code smell?

Using nested ternary operators are very confusing, and it makes it harder for other developers fix or maintain the code. Because of that, I extract this ternary operator to a 2-level nested if/else statements which will help other developers clearly see the flow of controls. The nested if/else statements make the code longer, but this fix helps improve readability of the code #24 