### PR TITLE
extract nested ternary operator Fixes #22

### DIFF
--- a/frontend/src/screens/ProductScreen.js
+++ b/frontend/src/screens/ProductScreen.js
@@ -57,17 +57,32 @@ const ProductScreen = ({ history, match }) => {
     )
   }
 
-  return (
-    <>
-      <Link className='btn btn-light my-3' to='/'>
-        Go Back
-      </Link>
-      {loading ? (
+  if (loading){
+    return (
+      <>
+        <Link className='btn btn-light my-3' to='/'>
+          Go Back
+        </Link>
         <Loader />
-      ) : error ? (
-        <Message variant='danger'>{error}</Message>
-      ) : (
+      </>)
+  }
+  
+  else {
+      if (error){
+        return (
+          <>
+            <Link className='btn btn-light my-3' to='/'>
+              Go Back
+            </Link>
+            <Message variant='danger'>{error}</Message>
+          </>
+        )}
+      else {
+        return (
         <>
+          <Link className='btn btn-light my-3' to='/'>
+            Go Back
+          </Link>
           <Meta title={product.name} />
           <Row>
             <Col md={6}>
@@ -215,10 +230,9 @@ const ProductScreen = ({ history, match }) => {
               </ListGroup>
             </Col>
           </Row>
-        </>
-      )}
-    </>
-  )
+        </>)
+      }
+  }
 }
 
 export default ProductScreen


### PR DESCRIPTION
# Why is this a code smell?

Using nested ternary operator make it difficult for other developers to read and understand the code. Bugs usually also appears when there's transfer of control, so using nested ternary operator make tracing the causes of the bugs even more difficult. Because of that, I have extract the ternary operator into 2-level nested if/else statements. The code using nested if/else statement can be a little bit longer, but it's easier to read and trace the flow of statements in the program #22 