### PR TITLE
Extract ternary operation from paginate func, Fixes #16

### DIFF
--- a/frontend/src/components/Paginate.js
+++ b/frontend/src/components/Paginate.js
@@ -3,19 +3,26 @@ import { Pagination } from 'react-bootstrap'
 import { LinkContainer } from 'react-router-bootstrap'
 
 const Paginate = ({ pages, page, isAdmin = false, keyword = '' }) => {
+
+  // fixes issue #16 
+  const pageLink = (x) => {
+    if (!isAdmin) {
+      if (keyword) {
+        return `/search/${keyword}/page/${x + 1}`
+      } else {
+        return `/page/${x + 1}`
+      }
+    } else {
+      return `/admin/productlist/${x + 1}`
+    }
+  }
   return (
     pages > 1 && (
       <Pagination>
         {[...Array(pages).keys()].map((x) => (
           <LinkContainer
             key={x + 1}
-            to={
-              !isAdmin
-                ? keyword
-                  ? `/search/${keyword}/page/${x + 1}`
-                  : `/page/${x + 1}`
-                : `/admin/productlist/${x + 1}`
-            }
+            to={pageLink()}
           >
             <Pagination.Item active={x + 1 === page}>{x + 1}</Pagination.Item>
           </LinkContainer>


### PR DESCRIPTION
# Why is this a code smell?
The ternary operator that was being used in this file was nested. This can make the code unreadable to a developer who is not familiar with this file. In order to fix it, I extracted the logic used in the ternary operator into a reusable function.

The function that I made is called "pageLink" which now handles the logic that the ternary operator was doing. This makes the code a lot cleaner and easier to read.